### PR TITLE
support for config file cmd line param

### DIFF
--- a/cmd/redirector/config.go
+++ b/cmd/redirector/config.go
@@ -18,8 +18,8 @@ type SingleRedirect struct {
 	UnixDst string `yaml:"unix-dst"`
 }
 
-func parseConfig() (Config, error) {
-	rawData, err := os.ReadFile("config.yml")
+func parseConfig(configFile string) (Config, error) {
+	rawData, err := os.ReadFile(configFile)
 	if err != nil {
 		return Config{}, errors.Wrap(err, "os.ReadFile")
 	}

--- a/cmd/redirector/main.go
+++ b/cmd/redirector/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"io"
 	"log"
 	"net"
@@ -19,7 +20,11 @@ const (
 )
 
 func main() {
-	conf, err := parseConfig()
+	var paramConfigFile string
+	flag.StringVar(&paramConfigFile, "config", "config.yml", "Config file to read")
+	flag.Parse()
+
+	conf, err := parseConfig(paramConfigFile)
 	if err != nil {
 		log.Fatal("Cannot load config: ", err)
 	}


### PR DESCRIPTION
In my use case I use the binary directly without docker. 
I have several configs which I run on different machines. Till today I copied the config and the binary in a new folder.
Because of this I added the possibility to read a different config file with the param -config "myconfig.yml"
This option is optional and has config.yml as default.

```
./redirector -h
Usage of ./redirector:
  -config string
    	Config file to read (default "config.yml")
```

```
./redirector -config "../../config.example.yml" 
2024/02/05 20:38:42 Started listening 127.0.0.1:8082 -> some/path/socket.sock
2024/02/05 20:38:42 Started listening 127.0.0.1:8081 -> 192.168.1.2:123
2024/02/05 20:38:42 Started listening :8080 -> google.com:80
```

if the file is not available the os.readfile will handle it.
```
./redirector -config test.yml
2024/02/05 20:34:25 Cannot load config: os.ReadFile: open test.yml: no such file or directory

```